### PR TITLE
fix(achievements): 實作任務進度自動同步與 UI 阻塞修復

### DIFF
--- a/src/components/AchievementsMission.vue
+++ b/src/components/AchievementsMission.vue
@@ -69,15 +69,26 @@ const emit = defineEmits(['reward-claimed'])
 
 // 領取獎勵
 const handleClaim = async (m) => {
+    if (m.isClaiming) return; // 🌟 防止重複點擊
+    
     try {
-        await claimMissionReward(m.miss_id)
-        ElMessage.success('領取獎勵成功！')
-        fetchMissions()
-        emit('reward-claimed'); // 通知父組件同步更新數據
+        m.isClaiming = true; // 開始領取，鎖定狀態
+        await claimMissionReward(m.miss_id);
+        ElMessage.success('領取獎勵成功！');
+        
+        // 成功後才執行這個，這會觸發父組件 handleGlobalSync
+        emit('reward-claimed'); 
+        
+        await fetchMissions(); // 重新整理列表
     } catch (error) {
-        console.error("領取失敗", error)
+        console.error("領取失敗", error);
+        // 如果失敗了，可以把按鈕還給用戶
+        m.isClaiming = false;
     }
-}
+};
+
+// 🌟 必須加上這行，父組件才呼叫得到！
+defineExpose({ fetchMissions });
 
 onMounted(() => {
     fetchMissions()

--- a/src/components/MoneyAIBot.vue
+++ b/src/components/MoneyAIBot.vue
@@ -581,9 +581,17 @@ const confirmRecord = async (msgId, index, data) => {
       msg.is_command = false;
       msg.text = `✅ 喵！已經幫小主人把所有帳都記好囉！`;
     }
-    // 🌟 這裡最重要！一定要在 Post 成功後發射
-    window.dispatchEvent(new CustomEvent('sync-money-data'));
-    console.log("📢 廣播：同步訊號已發出！");
+    
+    // window.dispatchEvent(new CustomEvent('sync-money-data'));
+    // console.log("📢 廣播：同步訊號已發出！");
+
+    // ✅ 改成延遲 300 毫秒再廣播，確保後端資料庫已經寫死進去了
+    setTimeout(() => {
+        window.dispatchEvent(new CustomEvent('sync-money-data'));
+        console.log("📢 廣播：同步訊號已發出 (延遲 500ms)！");
+    }, 500);
+
+
 
   } catch (error) {
     console.error("❌ 寫入失敗：", error);

--- a/src/view/Account.vue
+++ b/src/view/Account.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, onUnmounted } from 'vue';
 import { accountApi } from '@/api/account';
 import AccountAdd1 from '@/components/AccountAdd1.vue';
 import AccountEdit from '@/components/AccountEdit.vue';
@@ -89,7 +89,15 @@ onMounted(() => {
     window.addEventListener('click', closeMenu);
     fetchAccounts();
     triggerMissionAction('view_accounts');
-    window.addEventListener('sync-money-data', fetchTransactions);
+    //裡負責抓取帳戶清單的函數叫做 fetchAccounts
+    window.addEventListener('sync-money-data', fetchAccounts);
+});
+
+onUnmounted(() => {
+    // 離開時，把剛才裝的全部拆掉
+    window.removeEventListener('click', closeMenu);
+    window.removeEventListener('sync-money-data', fetchAccounts);
+    
 });
 
 // API 操作

--- a/src/view/Achievements.vue
+++ b/src/view/Achievements.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import AchievementsMission from '@/components/AchievementsMission.vue'
 import AchievementsCards from '@/components/AchievementsCards.vue'
@@ -171,10 +171,27 @@ const checkInDays = computed(() => {
     });
 });
 
+// 在 script setup 裡定義一個同步用的函數
+const handleGlobalSync = () => {
+    console.log("📢 成就頁面收到同步訊號，準備更新任務與 XP...");
+    fetchUserLevelSummary(); // 更新等級/XP
+
+    // 🌟 關鍵：手動去叫 Missions 組件更新
+    if (missionRef.value && missionRef.value.fetchMissions) {
+        missionRef.value.fetchMissions();
+        console.log("🔄 任務清單已指令更新");
+    }
+};
+
 onMounted(() => {
     fetchUserLevelSummary(); 
     fetchMyCheckinStatus(); 
-    window.addEventListener('sync-money-data', fetchTransactions); 
+    window.addEventListener('sync-money-data', handleGlobalSync);
+});
+
+onUnmounted(() => {
+    window.removeEventListener('sync-money-data', handleGlobalSync);
+
 });
 </script>
 

--- a/src/view/Book.vue
+++ b/src/view/Book.vue
@@ -3,7 +3,7 @@
     import BookTransactionDetails from "@/components/BookTransactionDetails.vue";
     import BookSummaryCard from "@/components/BookSummaryCard.vue";
     import api from "@/api";
-    import { ref, computed, onMounted, watch } from "vue";
+    import { ref, computed, onMounted, watch , onUnmounted} from "vue";
     import { ElMessage } from 'element-plus';
     import { getLocalDate, getLocalDateString } from '@/utils/dateHelper'
     import { triggerMissionAction } from '@/api/gamification';
@@ -75,7 +75,13 @@
         fetchTransactions();
         triggerMissionAction('view_calendar');
         window.addEventListener('sync-money-data', fetchTransactions);
+        
     });
+
+    onUnmounted(() => {
+    // 離開時，把剛才裝的全部拆掉
+    window.removeEventListener('sync-money-data', fetchTransactions);
+});
 
     // 當年份或月份改變時，重新抓取 API
     watch([year, month], () => {


### PR DESCRIPTION
詳細描述 (Description):

- [Component] 在 AchievementsMission.vue 使用 defineExpose 暴露 fetchMissions 函數，允許父組件呼叫。
(Expose fetchMissions via defineExpose for parent component access.)

- [Sync] 在 AI Bot 的 sync-money-data 事件增加 500ms 延遲，避免與資料庫寫入產生競爭條件 (Race Condition)。
(Add 500ms delay to AI bot sync event to prevent Race Condition with DB.)

- [Lifecycle] 在 Achievements.vue 註冊監聽器並調整 onUnmounted 清理邏輯，優化內存使用。
(Register listener and implement onUnmounted cleanup in Achievements page.)